### PR TITLE
Add tests for mapping and numeric helper functions

### DIFF
--- a/dnsjson_internal_test.go
+++ b/dnsjson_internal_test.go
@@ -1,6 +1,7 @@
 package dnsjson
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ func TestStringToType(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "known mnemonic", input: "A", want: dns.TypeA},
+		{name: "case insensitive", input: "a", want: dns.TypeA},
 		{name: "numeric string", input: "15", want: dns.TypeMX},
 		{name: "unknown", input: "definitely-unknown", wantErr: true},
 	}
@@ -37,6 +39,87 @@ func TestStringToType(t *testing.T) {
 				t.Fatalf("stringToType(%q) = %d, want %d", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestClassToString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   uint16
+		want string
+	}{
+		{name: "known class", in: dns.ClassINET, want: "IN"},
+		{name: "unknown class", in: 9999, want: "9999"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classToString(tc.in); got != tc.want {
+				t.Fatalf("classToString(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStringToClass(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "known mnemonic", input: "IN", want: dns.ClassINET},
+		{name: "case insensitive", input: "in", want: dns.ClassINET},
+		{name: "numeric string", input: "254", want: 254},
+		{name: "unknown", input: "definitely-unknown", wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := stringToClass(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("stringToClass(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetUintHelpers(t *testing.T) {
+	t.Parallel()
+	m := map[string]any{
+		"u8":   float64(42),
+		"u16":  int(65535),
+		"u32n": json.Number("123456"),
+		"u32s": "789",
+	}
+
+	if got := getUint8(m, "u8"); got != 42 {
+		t.Fatalf("getUint8 = %d, want 42", got)
+	}
+	if got := getUint16(m, "u16"); got != 65535 {
+		t.Fatalf("getUint16 = %d, want 65535", got)
+	}
+	if got := getUint32(m, "u32n"); got != 123456 {
+		t.Fatalf("getUint32(json.Number) = %d, want 123456", got)
+	}
+	if got := getUint32(m, "u32s"); got != 789 {
+		t.Fatalf("getUint32(string) = %d, want 789", got)
+	}
+	if got := getUint16(m, "missing"); got != 0 {
+		t.Fatalf("getUint16 missing key = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- extend stringToType coverage to include case-insensitive inputs
- add new tests for classToString and stringToClass helper conversions
- cover getUint helper functions across multiple input value types

## Testing
- GOPROXY=direct GOSUMDB=off go test ./... -cover -v

------
https://chatgpt.com/codex/tasks/task_b_68cbdb76b594832c883d0b086b4ab05a